### PR TITLE
Change the website link to direct to club site

### DIFF
--- a/src/screens/About.tsx
+++ b/src/screens/About.tsx
@@ -18,8 +18,8 @@ const socials: Social[] = [
   },
   {
     type: SocialTypes.Website,
-    text: 'Check out our Website',
-    url: 'https://www.knighthacks.org/',
+    text: 'Check out our Team',
+    url: 'https://club.knighthacks.org/',
     logo: <Foundation name="web" size={28} color="black" />,
   },
   {


### PR DESCRIPTION
The reason for this is that the redirect for knighthacks.org will be changed from club site to registration site soon. Since the user will not want to register again, they can come and check out our team on the club site. 